### PR TITLE
Made counter metric to report value

### DIFF
--- a/txstatsd/metrics/countermetric.py
+++ b/txstatsd/metrics/countermetric.py
@@ -44,12 +44,12 @@ class CounterMetric(Metric):
     def increment(self, value):
         """Increment the counter by C{value}"""
         self._count += value
-        self._update(self._count)
+        self._update(value)
 
     def decrement(self, value):
         """Decrement the counter by C{value}"""
         self._count -= value
-        self._update(self._count)
+        self._update(-value)
 
     def count(self):
         """Returns the counter's current value."""


### PR DESCRIPTION
StatsD client shouldn't maintain any count as that's the job of statsd server. This client suffers from this problem of keeping a local count and sending it after to statsd server.

As a result, this messes up the reported data. 